### PR TITLE
Add listeners to Orders and Tickets services

### DIFF
--- a/orders/package-lock.json
+++ b/orders/package-lock.json
@@ -907,9 +907,9 @@
       }
     },
     "@saheedpass/common": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@saheedpass/common/-/common-1.0.9.tgz",
-      "integrity": "sha512-qIeR6Kovka/+dj/jMY4E9wb8929a/f/ouLtHYNU/Z75ZTF2rRssiWmoRCuZgB3oldZkojbhBAt8gZzJuPn0HuQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@saheedpass/common/-/common-1.0.10.tgz",
+      "integrity": "sha512-SnT1pulo17UwalUxG3AlSTrZ4mSwkFeDuGR9R/Jg2m2DW7SW5QEk4HJ5ASv2tVqBgH0LCz2aJIoQWkxKuHB61w==",
       "requires": {
         "@types/cookie-session": "^2.0.40",
         "@types/express": "^4.17.6",
@@ -2018,6 +2018,11 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
+    },
+    "core-js": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -5154,6 +5159,16 @@
       "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
     },
+    "mongoose-update-if-current": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mongoose-update-if-current/-/mongoose-update-if-current-1.4.0.tgz",
+      "integrity": "sha512-Rau2nvdiLExqXrSOwMMgDYQgf/fwTJQpPidTcT7C9UMQ282gTKXjDuh5vrjVvVQpfuvkiPis0tGHdXffaD54bg==",
+      "requires": {
+        "core-js": "^3.2.1",
+        "kareem": "^2.3.0",
+        "regenerator-runtime": "^0.13.5"
+      }
+    },
     "mpath": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.7.0.tgz",
@@ -5716,6 +5731,11 @@
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regex-not": {
       "version": "1.0.2",

--- a/orders/package-lock.json
+++ b/orders/package-lock.json
@@ -907,9 +907,9 @@
       }
     },
     "@saheedpass/common": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@saheedpass/common/-/common-1.0.10.tgz",
-      "integrity": "sha512-SnT1pulo17UwalUxG3AlSTrZ4mSwkFeDuGR9R/Jg2m2DW7SW5QEk4HJ5ASv2tVqBgH0LCz2aJIoQWkxKuHB61w==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@saheedpass/common/-/common-1.0.11.tgz",
+      "integrity": "sha512-y4qwPSfTylPlQR0LNARwJNf0a1vN4vuG8G8RI/LhLDrpRECDyv9/s+qCC3tm8AsRNCLs/x2s4y4bPfvMQiBfgA==",
       "requires": {
         "@types/cookie-session": "^2.0.40",
         "@types/express": "^4.17.6",

--- a/orders/package.json
+++ b/orders/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@saheedpass/common": "^1.0.9",
+    "@saheedpass/common": "^1.0.10",
     "@types/cookie-session": "^2.0.40",
     "@types/express": "^4.17.6",
     "@types/jsonwebtoken": "^8.5.0",
@@ -29,6 +29,7 @@
     "express-validator": "^6.5.0",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.9.18",
+    "mongoose-update-if-current": "^1.4.0",
     "ts-node-dev": "^1.0.0-pre.44",
     "typescript": "^3.9.5"
   },

--- a/orders/package.json
+++ b/orders/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@saheedpass/common": "^1.0.10",
+    "@saheedpass/common": "^1.0.11",
     "@types/cookie-session": "^2.0.40",
     "@types/express": "^4.17.6",
     "@types/jsonwebtoken": "^8.5.0",

--- a/orders/src/db/models/order.ts
+++ b/orders/src/db/models/order.ts
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import { updateIfCurrentPlugin } from 'mongoose-update-if-current';
 import { OrderStatus } from '@saheedpass/common';
 import { TicketDoc } from './ticket';
 
@@ -11,6 +12,7 @@ interface OrderAttrs {
 
 interface OrderDoc extends mongoose.Document {
   userId: string;
+  version: number;
   status: OrderStatus;
   expiresAt: Date;
   ticket: TicketDoc;
@@ -49,6 +51,9 @@ const orderSchema = new mongoose.Schema(
     }
   }
 );
+
+orderSchema.set('versionKey', 'version');
+orderSchema.plugin(updateIfCurrentPlugin);
 
 orderSchema.statics.build = (attrs: OrderAttrs) => {
   return new Order(attrs);

--- a/orders/src/db/models/ticket.ts
+++ b/orders/src/db/models/ticket.ts
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import { updateIfCurrentPlugin } from 'mongoose-update-if-current';
 import { Order, OrderStatus } from './order';
 
 interface TicketAttrs{
@@ -9,10 +10,12 @@ interface TicketAttrs{
 export interface TicketDoc extends mongoose.Document{
   title: string;
   price: number;
+  version: number;
   isReserved(): Promise<boolean>
 }
 interface TicketModel extends mongoose.Model<TicketDoc>{
   build(attrs: TicketAttrs): TicketDoc;
+  findByIdAndPrevVersion(event: { id: string, version: number }): Promise<TicketDoc | null>;
 }
 
 const ticketSchema = new mongoose.Schema({
@@ -34,6 +37,15 @@ const ticketSchema = new mongoose.Schema({
   }
 });
 
+ticketSchema.set('versionKey', 'version');
+ticketSchema.plugin(updateIfCurrentPlugin);
+
+ticketSchema.statics.findByIdAndPrevVersion = (event: { id: string, version: number }) => {
+  return Ticket.findOne({
+    _id: event.id,
+    version: event.version - 1
+  })
+};
 ticketSchema.statics.build = (attrs: TicketAttrs) => {
   return new Ticket({
     _id: attrs.id,

--- a/orders/src/db/models/ticket.ts
+++ b/orders/src/db/models/ticket.ts
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 import { Order, OrderStatus } from './order';
 
 interface TicketAttrs{
+  id: string;
   title: string;
   price: number;
 }
@@ -34,7 +35,11 @@ const ticketSchema = new mongoose.Schema({
 });
 
 ticketSchema.statics.build = (attrs: TicketAttrs) => {
-  return new Ticket(attrs);
+  return new Ticket({
+    _id: attrs.id,
+    title: attrs.title,
+    price: attrs.price
+  });
 };
 ticketSchema.methods.isReserved = async function () {
   const existingOrder = await Order.findOne({

--- a/orders/src/events/listeners/__test__/ticket-created-listener.test.ts
+++ b/orders/src/events/listeners/__test__/ticket-created-listener.test.ts
@@ -1,0 +1,42 @@
+import { Message } from 'node-nats-streaming';
+import mongoose from 'mongoose';
+import { TicketCreatedEvent } from '@saheedpass/common';
+import { TicketCreatedListener } from '../ticket-created-listener';
+import { natsClientWrapper } from '../../../nats-client-wrapper';
+import { Ticket } from '../../../db/models/ticket';
+const setup = async () => {
+  const listener = new TicketCreatedListener(natsClientWrapper.client);
+
+  const data: TicketCreatedEvent['data'] = {
+    id: new mongoose.Types.ObjectId().toHexString(),
+    version: 0,
+    title: 'tester',
+    price: 20,
+    userId: new mongoose.Types.ObjectId().toHexString()
+  };
+  // @ts-ignore
+  const msg: Message = {
+    ack: jest.fn()
+  };
+  return { listener, data, msg };
+};
+
+it('creates and saves a ticket', async () => {
+  const { listener, data, msg } = await setup();
+
+  await listener.onMessage(data, msg);
+
+  const ticket = await Ticket.findById(data.id);
+  
+  expect(ticket).toBeDefined();
+  expect(ticket!.title).toEqual(data.title);
+  expect(ticket!.price).toEqual(data.price);
+});
+
+it('acks the message', async () => {
+  const { listener, data, msg } = await setup();
+
+  await listener.onMessage(data, msg);
+
+  expect(msg.ack).toHaveBeenCalled()
+})

--- a/orders/src/events/listeners/__test__/ticket-update-listener.test.ts
+++ b/orders/src/events/listeners/__test__/ticket-update-listener.test.ts
@@ -1,0 +1,67 @@
+import mongoose from 'mongoose';
+import { Message } from 'node-nats-streaming';
+import { TicketUpdatedEvent } from '@saheedpass/common';
+import { TicketUpdatedListener } from '../ticket-updated-listener';
+import { natsClientWrapper } from '../../../nats-client-wrapper';
+import { Ticket } from '../../../db/models/ticket';
+
+const setup = async () => {
+  const listener = new TicketUpdatedListener(natsClientWrapper.client);
+  
+  const ticket = Ticket.build({
+    id: mongoose.Types.ObjectId().toHexString(),
+    title: 'test',
+    price: 50,
+  });
+  await ticket.save();
+
+  const data: TicketUpdatedEvent['data'] = {
+    id: ticket.id,
+    version: ticket.version + 1,
+    title: ' new tester',
+    price: 80,
+    userId: 'knnjbjbjb'
+  };
+
+  // @ts-ignore
+  const msg: Message = {
+    ack: jest.fn()
+  }
+
+  return { msg, data, ticket, listener };
+};
+
+it('finds, updates, and saves a ticket', async () => {
+  const { msg, data, ticket, listener } = await setup();
+
+  await listener.onMessage(data, msg);
+
+  const updatedTicket = await Ticket.findById(ticket.id);
+  
+  expect(updatedTicket!.title).toEqual(data.title);
+  expect(updatedTicket!.price).toEqual(data.price);
+  expect(updatedTicket!.version).toEqual(data.version);
+});
+
+it('acks the message', async () => {
+  const { msg, data, listener } = await setup();
+
+  await listener.onMessage(data, msg);
+
+  expect(msg.ack).toHaveBeenCalled();
+});
+
+it('does not call ack if the event version is out of sync', async () => {
+  const { msg, data, ticket, listener } = await setup();
+
+  data.version = 10;
+
+  // we are using try/catch as making an async assertion
+  // is impossible for now.
+  try {
+    await listener.onMessage(data, msg);
+  } catch (error) { }
+  
+  expect(msg.ack).not.toHaveBeenCalled();
+
+});

--- a/orders/src/events/listeners/queue-group/queue-group-name.ts
+++ b/orders/src/events/listeners/queue-group/queue-group-name.ts
@@ -1,0 +1,1 @@
+export const queueGroupName = 'orders-service';

--- a/orders/src/events/listeners/ticket-created-listener.ts
+++ b/orders/src/events/listeners/ticket-created-listener.ts
@@ -1,0 +1,17 @@
+import { Message } from 'node-nats-streaming';
+import { Subjects, Listener, TicketCreatedEvent } from '@saheedpass/common';
+import { Ticket } from '../../db/models/ticket';
+import { queueGroupName } from './queue-group/queue-group-name';
+
+export class TicketCreatedListener extends Listener<TicketCreatedEvent> {
+  subject: Subjects.TicketCreated = Subjects.TicketCreated;
+  queueGroupName = queueGroupName;
+  
+  async onMessage(data: TicketCreatedEvent['data'], msg: Message) {
+    const { id, title, price } = data;
+    const ticket = Ticket.build({ id, title, price });
+    await ticket.save();
+
+    msg.ack();
+  }
+}

--- a/orders/src/events/listeners/ticket-updated-listener.ts
+++ b/orders/src/events/listeners/ticket-updated-listener.ts
@@ -1,0 +1,23 @@
+import { Message } from 'node-nats-streaming';
+import { Subjects, Listener, TicketUpdatedEvent } from '@saheedpass/common';
+import { Ticket } from '../../db/models/ticket';
+import { queueGroupName } from './queue-group/queue-group-name';
+
+export class TicketUpdatedListener extends Listener<TicketUpdatedEvent> {
+  subject: Subjects.TicketUpdated = Subjects.TicketUpdated;
+  queueGroupName = queueGroupName;
+
+  async onMessage(data: TicketUpdatedEvent['data'], msg: Message) {
+    const { id, title, price } = data;
+
+    const ticket = await Ticket.findById(id);
+    if (!ticket) {
+      throw new Error('Ticket not found');
+    }
+
+    ticket.set({ title, price });
+    await ticket.save();
+
+    msg.ack();
+  }
+}

--- a/orders/src/events/listeners/ticket-updated-listener.ts
+++ b/orders/src/events/listeners/ticket-updated-listener.ts
@@ -10,7 +10,8 @@ export class TicketUpdatedListener extends Listener<TicketUpdatedEvent> {
   async onMessage(data: TicketUpdatedEvent['data'], msg: Message) {
     const { id, title, price } = data;
 
-    const ticket = await Ticket.findById(id);
+    const ticket = await Ticket.findByIdAndPrevVersion(data);
+
     if (!ticket) {
       throw new Error('Ticket not found');
     }

--- a/orders/src/index.ts
+++ b/orders/src/index.ts
@@ -2,6 +2,8 @@ import mongoose from 'mongoose';
 
 import { app } from './app';
 import { natsClientWrapper } from './nats-client-wrapper';
+import { TicketCreatedListener } from './events/listeners/ticket-created-listener';
+import { TicketUpdatedListener } from './events/listeners/ticket-updated-listener';
 
 const start = async () => {
   if (!process.env.JWT_SECRET) {
@@ -34,6 +36,9 @@ const start = async () => {
     });
     process.on('SIGINT', () => natsClientWrapper.client.close());
     process.on('SIGINT', () => natsClientWrapper.client.close());
+
+    new TicketCreatedListener(natsClientWrapper.client).listen();
+    new TicketUpdatedListener(natsClientWrapper.client).listen();
 
     await mongoose.connect(process.env.MONGO_URI, {
       useNewUrlParser: true,

--- a/orders/src/routes/__test__/delete.test.ts
+++ b/orders/src/routes/__test__/delete.test.ts
@@ -7,7 +7,11 @@ import { getCookie } from '../../test/auth-helper';
 import { natsClientWrapper } from '../../nats-client-wrapper';
 
 it('marks an order cancelled', async () => {
-  const ticket = Ticket.build({ title: 'test', price: 20 });
+  const ticket = Ticket.build({
+    id: mongoose.Types.ObjectId().toHexString(),
+    title: 'test',
+    price: 20
+  });
   await ticket.save();
 
   const cookie = getCookie();
@@ -29,7 +33,11 @@ it('marks an order cancelled', async () => {
 });
 
 it('returns unauthorized error if trying to cancel order belonging to another user', async () => {
-  const ticket = Ticket.build({ title: 'test', price: 20 });
+  const ticket = Ticket.build({
+    id: mongoose.Types.ObjectId().toHexString(),
+    title: 'test',
+    price: 20
+  });
   await ticket.save();
 
   const cookie = getCookie();
@@ -48,7 +56,11 @@ it('returns unauthorized error if trying to cancel order belonging to another us
 });
 
 it('returns not found error if trying to cancel non-existing order', async () => {
-  const ticket = Ticket.build({ title: 'test', price: 20 });
+  const ticket = Ticket.build({
+    id: mongoose.Types.ObjectId().toHexString(),
+    title: 'test',
+    price: 20
+  });
   await ticket.save();
 
   const cookie = getCookie();
@@ -68,7 +80,11 @@ it('returns not found error if trying to cancel non-existing order', async () =>
 });
 
 it('emits an order cancelled event', async () => {
-  const ticket = Ticket.build({ title: 'test', price: 20 });
+  const ticket = Ticket.build({
+    id: mongoose.Types.ObjectId().toHexString(),
+    title: 'test',
+    price: 20
+  });
   await ticket.save();
 
   const cookie = getCookie();

--- a/orders/src/routes/__test__/index.test.ts
+++ b/orders/src/routes/__test__/index.test.ts
@@ -1,12 +1,12 @@
 import mongoose from 'mongoose';
 import request from 'supertest';
 import { app } from '../../app';
-import { Order, OrderStatus } from '../../db/models/order';
 import { Ticket } from '../../db/models/ticket';
 import { getCookie } from '../../test/auth-helper';
 
 const buildTicket = async (title: string, price: number) => {
   const ticket = Ticket.build({
+    id: mongoose.Types.ObjectId().toHexString(),
     title,
     price
   });

--- a/orders/src/routes/__test__/new.test.ts
+++ b/orders/src/routes/__test__/new.test.ts
@@ -18,6 +18,7 @@ it('returns an error if ticket does not exist', async () => {
 
 it('returns an error if the ticket is already reserved', async () => {
   const ticket = Ticket.build({
+    id: mongoose.Types.ObjectId().toHexString(),
     title: 'test ticket',
     price: 20
   });
@@ -39,6 +40,7 @@ it('returns an error if the ticket is already reserved', async () => {
 
 it('reserves a ticket', async () => {
   const ticket = Ticket.build({
+    id: mongoose.Types.ObjectId().toHexString(),
     title: 'test ticket',
     price: 20
   });
@@ -56,6 +58,7 @@ it('reserves a ticket', async () => {
 
 it('emits an order:created event', async () => {
   const ticket = Ticket.build({
+    id: mongoose.Types.ObjectId().toHexString(),
     title: 'test ticket',
     price: 20
   });

--- a/orders/src/routes/__test__/show.test.ts
+++ b/orders/src/routes/__test__/show.test.ts
@@ -5,7 +5,11 @@ import { Ticket } from '../../db/models/ticket';
 import { getCookie } from '../../test/auth-helper';
 
 it('fetches an order', async () => {
-  const ticket = Ticket.build({ title: 'test', price: 20 });
+  const ticket = Ticket.build({
+    id: mongoose.Types.ObjectId().toHexString(),
+    title: 'test',
+    price: 20
+  });
   await ticket.save();
 
   const cookie = getCookie();
@@ -26,7 +30,11 @@ it('fetches an order', async () => {
 });
 
 it('returns error if order belongs to another user', async () => {
-  const ticket = Ticket.build({ title: 'test', price: 20 });
+  const ticket = Ticket.build({
+    id: mongoose.Types.ObjectId().toHexString(),
+    title: 'test',
+    price: 20
+  });
   await ticket.save();
 
   const cookie = getCookie();
@@ -45,7 +53,11 @@ it('returns error if order belongs to another user', async () => {
 });
 
 it('returns error if order is not found', async () => {
-  const ticket = Ticket.build({ title: 'test', price: 20 });
+  const ticket = Ticket.build({
+    id: mongoose.Types.ObjectId().toHexString(),
+    title: 'test',
+    price: 20
+  });
   await ticket.save();
 
   const cookie = getCookie();

--- a/orders/src/routes/delete.ts
+++ b/orders/src/routes/delete.ts
@@ -25,6 +25,7 @@ router.delete('/api/v1/orders/:orderId', requireAuth, async (req: Request, res: 
   // publish order:cancelled event
   new OrderCancelledPublisher(natsClientWrapper.client).publish({
     id: order.id,
+    version: order.version,
     ticket: {
       id: order.ticket.id
     }

--- a/orders/src/routes/new.ts
+++ b/orders/src/routes/new.ts
@@ -47,6 +47,7 @@ router.post(
     // publish order:created event 
     new OrderCreatedPublisher(natsClientWrapper.client).publish({
       id: order.id,
+      version: order.version,
       status: order.status,
       userId: order.userId,
       expiresAt: order.expiresAt.toISOString(),

--- a/tickets/package-lock.json
+++ b/tickets/package-lock.json
@@ -2019,6 +2019,11 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "core-js": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -5154,6 +5159,16 @@
       "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
     },
+    "mongoose-update-if-current": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mongoose-update-if-current/-/mongoose-update-if-current-1.4.0.tgz",
+      "integrity": "sha512-Rau2nvdiLExqXrSOwMMgDYQgf/fwTJQpPidTcT7C9UMQ282gTKXjDuh5vrjVvVQpfuvkiPis0tGHdXffaD54bg==",
+      "requires": {
+        "core-js": "^3.2.1",
+        "kareem": "^2.3.0",
+        "regenerator-runtime": "^0.13.5"
+      }
+    },
     "mpath": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.7.0.tgz",
@@ -5716,6 +5731,11 @@
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regex-not": {
       "version": "1.0.2",

--- a/tickets/package-lock.json
+++ b/tickets/package-lock.json
@@ -907,9 +907,9 @@
       }
     },
     "@saheedpass/common": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@saheedpass/common/-/common-1.0.10.tgz",
-      "integrity": "sha512-SnT1pulo17UwalUxG3AlSTrZ4mSwkFeDuGR9R/Jg2m2DW7SW5QEk4HJ5ASv2tVqBgH0LCz2aJIoQWkxKuHB61w==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@saheedpass/common/-/common-1.0.11.tgz",
+      "integrity": "sha512-y4qwPSfTylPlQR0LNARwJNf0a1vN4vuG8G8RI/LhLDrpRECDyv9/s+qCC3tm8AsRNCLs/x2s4y4bPfvMQiBfgA==",
       "requires": {
         "@types/cookie-session": "^2.0.40",
         "@types/express": "^4.17.6",

--- a/tickets/package-lock.json
+++ b/tickets/package-lock.json
@@ -907,9 +907,9 @@
       }
     },
     "@saheedpass/common": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@saheedpass/common/-/common-1.0.6.tgz",
-      "integrity": "sha512-Y5K60OB7l8lukFV4T+cWbdnnjXpW1YHN5PYip6cKwgtpjxqEn6nAeecHnSRozSSVwiGrzQKwmO9CM8vfF7PdRA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@saheedpass/common/-/common-1.0.10.tgz",
+      "integrity": "sha512-SnT1pulo17UwalUxG3AlSTrZ4mSwkFeDuGR9R/Jg2m2DW7SW5QEk4HJ5ASv2tVqBgH0LCz2aJIoQWkxKuHB61w==",
       "requires": {
         "@types/cookie-session": "^2.0.40",
         "@types/express": "^4.17.6",

--- a/tickets/package.json
+++ b/tickets/package.json
@@ -29,6 +29,7 @@
     "express-validator": "^6.5.0",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.9.18",
+    "mongoose-update-if-current": "^1.4.0",
     "ts-node-dev": "^1.0.0-pre.44",
     "typescript": "^3.9.5"
   },

--- a/tickets/package.json
+++ b/tickets/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@saheedpass/common": "^1.0.10",
+    "@saheedpass/common": "^1.0.11",
     "@types/cookie-session": "^2.0.40",
     "@types/express": "^4.17.6",
     "@types/jsonwebtoken": "^8.5.0",

--- a/tickets/package.json
+++ b/tickets/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@saheedpass/common": "^1.0.6",
+    "@saheedpass/common": "^1.0.10",
     "@types/cookie-session": "^2.0.40",
     "@types/express": "^4.17.6",
     "@types/jsonwebtoken": "^8.5.0",

--- a/tickets/src/db/models/__test__/ticket.test.ts
+++ b/tickets/src/db/models/__test__/ticket.test.ts
@@ -1,0 +1,31 @@
+import { Ticket } from '../ticket';
+
+it('implements optimistic concurrency control', async (done) => {
+  const ticket = Ticket.build({
+    title: 'mov',
+    price: 12,
+    userId: 'khabbfaj'
+  })
+
+  await ticket.save();
+
+  const firstInstance = await Ticket.findById(ticket.id);
+  const secondInstance = await Ticket.findById(ticket.id);
+
+  firstInstance!.set({ price: 15 });
+  secondInstance!.set({ price: 20 });
+  
+  await firstInstance!.save();
+
+  // because of jest issues with typescript when using
+  // async function in a expect like so:
+  // expect(async ()=> ).toThrow(), we will be using a
+  // A TRY/CATCH trick to test this.
+  try {
+    await secondInstance!.save();
+  } catch (err) {
+    return done();
+  }
+
+  throw new Error('Should not reach this point');
+});

--- a/tickets/src/db/models/__test__/ticket.test.ts
+++ b/tickets/src/db/models/__test__/ticket.test.ts
@@ -29,3 +29,18 @@ it('implements optimistic concurrency control', async (done) => {
 
   throw new Error('Should not reach this point');
 });
+
+it('increments version number on multiple saves', async () => {
+  const ticket = Ticket.build({
+    title: 'mov',
+    price: 12,
+    userId: 'khabbfaj'
+  });
+
+  await ticket.save();
+  expect(ticket.version).toEqual(0);
+  await ticket.save();
+  expect(ticket.version).toEqual(1);
+  await ticket.save();
+  expect(ticket.version).toEqual(2);
+})

--- a/tickets/src/db/models/ticket.ts
+++ b/tickets/src/db/models/ticket.ts
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import { updateIfCurrentPlugin } from 'mongoose-update-if-current';
 
 interface TicketAttrs {
   title: string;
@@ -10,6 +11,7 @@ interface TicketDoc extends mongoose.Document {
   title: string;
   price: number;
   userId: string;
+  version: number;
 }
 
 interface TicketModel extends mongoose.Model<TicketDoc>{
@@ -37,6 +39,8 @@ const ticketSchema = new mongoose.Schema({
     }
   }
 });
+ticketSchema.set('versionKey', 'version');
+ticketSchema.plugin(updateIfCurrentPlugin);
 
 ticketSchema.statics.build = (attrs: TicketAttrs) => {
   return new Ticket(attrs);

--- a/tickets/src/db/models/ticket.ts
+++ b/tickets/src/db/models/ticket.ts
@@ -12,6 +12,7 @@ interface TicketDoc extends mongoose.Document {
   price: number;
   userId: string;
   version: number;
+  orderId?: string;
 }
 
 interface TicketModel extends mongoose.Model<TicketDoc>{
@@ -30,6 +31,9 @@ const ticketSchema = new mongoose.Schema({
   userId: {
     type: String,
     required: true
+  },
+  orderId: {
+    type: String
   }
 }, {
     toJSON: {

--- a/tickets/src/events/listeners/__test__/order-cancelled-listener.test.ts
+++ b/tickets/src/events/listeners/__test__/order-cancelled-listener.test.ts
@@ -1,0 +1,47 @@
+import mongoose from 'mongoose';
+import { Message } from 'node-nats-streaming';
+import { OrderCancelledEvent, OrderStatus } from '@saheedpass/common';
+import { OrderCancelledListener } from '../order-cancelled-listener';
+import { natsClientWrapper } from '../../../nats-client-wrapper';
+import { Ticket } from '../../../db/models/ticket';
+
+
+const setup = async () => {
+  const listener = new OrderCancelledListener(natsClientWrapper.client);
+
+  const orderId = mongoose.Types.ObjectId().toHexString();
+  const ticket = Ticket.build({
+    title: 'test',
+    price: 30,
+    userId: 'dnsna',
+  });
+  ticket.set({ orderId });
+  await ticket.save();
+
+  const data: OrderCancelledEvent['data'] = {
+    id: orderId,
+    version: 0,
+    ticket: {
+      id: ticket.id
+    }
+  };
+
+  // @ts-ignore
+  const msg: Message = {
+    ack: jest.fn()
+  };
+
+  return { listener, orderId, ticket, data, msg };
+}
+
+it('updates ticket, publishes an event and acks the message', async () => {
+  const { msg, data, ticket, orderId, listener } = await setup();
+
+  await listener.onMessage(data, msg);
+
+  const updateTicket = await Ticket.findById(ticket.id);
+
+  expect(updateTicket!.orderId).not.toBeDefined();
+  expect(msg.ack).toHaveBeenCalled();
+  expect(natsClientWrapper.client.publish).toHaveBeenCalled();
+});

--- a/tickets/src/events/listeners/__test__/order-created-listener.test.ts
+++ b/tickets/src/events/listeners/__test__/order-created-listener.test.ts
@@ -1,0 +1,66 @@
+import mongoose from 'mongoose';
+import { Message } from 'node-nats-streaming';
+import { OrderCreatedEvent, OrderStatus } from '@saheedpass/common';
+import { OrderCreatedListener } from '../order-created-listener';
+import { natsClientWrapper } from '../../../nats-client-wrapper';
+import { Ticket } from '../../../db/models/ticket';
+
+const setup = async () => {
+  const listener = new OrderCreatedListener(natsClientWrapper.client);
+
+  const ticket = Ticket.build({
+    title: 'test T',
+    price: 30,
+    userId: 'jddsssjcsj'
+  });
+
+  await ticket.save();
+
+  const data: OrderCreatedEvent['data'] = {
+    id: mongoose.Types.ObjectId().toHexString(),
+    version: 0,
+    status: OrderStatus.Created,
+    userId: 'jddsssjcsj',
+    expiresAt: 'jsjsjs',
+    ticket: {
+      id: ticket.id,
+      price: ticket.price,
+    }
+  };
+  // @ts-ignore
+  const msg: Message = {
+    ack: jest.fn()
+  };
+
+  return { listener, ticket, data, msg };
+};
+
+it('sets userId of the ticket', async () => {
+  const { listener, ticket, data, msg } = await setup();
+
+  await listener.onMessage(data, msg);
+
+  const updatedTicket = await Ticket.findById(ticket.id);
+
+  expect(updatedTicket!.orderId).toEqual(data.id);
+});
+
+it('acks the message', async () => {
+  const { listener, ticket, data, msg } = await setup();
+
+  await listener.onMessage(data, msg);
+
+  expect(msg.ack).toHaveBeenCalled();
+});
+
+it('publishes a ticket updated event', async()=> {
+  const { listener, ticket, data, msg } = await setup();
+
+  await listener.onMessage(data, msg);
+
+  expect(natsClientWrapper.client.publish).toHaveBeenCalled();
+  
+  const ticketUpdatedData = JSON.parse((natsClientWrapper.client.publish as jest.Mock).mock.calls[0][1]);
+
+  expect(data.id).toEqual(ticketUpdatedData.orderId);
+});

--- a/tickets/src/events/listeners/order-cancelled-listener.ts
+++ b/tickets/src/events/listeners/order-cancelled-listener.ts
@@ -1,0 +1,31 @@
+import { Message } from 'node-nats-streaming';
+import { Listener, OrderCancelledEvent, Subjects } from '@saheedpass/common';
+import { queueGroupName } from './queue-group/queue-group-name';
+import { Ticket } from '../../db/models/ticket';
+import { TicketUpdatedPublisher } from '../publishers/ticket-update-publisher';
+
+export class OrderCancelledListener extends Listener<OrderCancelledEvent> {
+  subject: Subjects.OrderCancelled = Subjects.OrderCancelled;
+  queueGroupName = queueGroupName;
+
+  async onMessage(data: OrderCancelledEvent['data'], msg: Message) {
+    const ticket = await Ticket.findById(data.ticket.id);
+
+    if (!ticket) {
+      throw new Error('Ticket not found');
+    }
+
+    ticket.set({ orderId: undefined });
+    await ticket.save();
+    await new TicketUpdatedPublisher(this.client).publish({
+      id: ticket.id,
+      orderId: ticket.orderId,
+      userId: ticket.userId,
+      price: ticket.price,
+      title: ticket.title,
+      version: ticket.version,
+    });
+
+    msg.ack();
+  }
+}

--- a/tickets/src/events/listeners/order-created-listener.ts
+++ b/tickets/src/events/listeners/order-created-listener.ts
@@ -1,0 +1,32 @@
+import { Message } from 'node-nats-streaming';
+import { Listener, OrderCreatedEvent, Subjects } from '@saheedpass/common';
+import { queueGroupName } from './queue-group/queue-group-name';
+import { Ticket } from '../../db/models/ticket';
+import { TicketUpdatedPublisher } from '../publishers/ticket-update-publisher';
+
+export class OrderCreatedListener extends Listener<OrderCreatedEvent> {
+  subject: Subjects.OrderCreated = Subjects.OrderCreated;
+  queueGroupName = queueGroupName;
+
+  async onMessage(data: OrderCreatedEvent['data'], msg: Message) {
+    const ticket = await Ticket.findById(data.ticket.id);
+
+    if (!ticket) {
+      throw new Error('Ticket not found');
+    }
+
+    ticket.set({ orderId: data.id });
+    
+    await ticket.save();
+    await new TicketUpdatedPublisher(this.client).publish({
+      id: ticket.id,
+      version: ticket.version,
+      title: ticket.title,
+      price: ticket.price,
+      userId: ticket.userId,
+      orderId: ticket.orderId
+    });
+
+    msg.ack();
+  }
+}

--- a/tickets/src/events/listeners/queue-group/queue-group-name.ts
+++ b/tickets/src/events/listeners/queue-group/queue-group-name.ts
@@ -1,0 +1,1 @@
+export const queueGroupName = 'tickets-service';

--- a/tickets/src/index.ts
+++ b/tickets/src/index.ts
@@ -2,6 +2,8 @@ import mongoose from 'mongoose';
 
 import { app } from './app';
 import { natsClientWrapper } from './nats-client-wrapper';
+import { OrderCreatedListener } from './events/listeners/order-created-listener';
+import { OrderCancelledListener } from './events/listeners/order-cancelled-listener';
 
 const start = async () => {
   if (!process.env.JWT_SECRET) {
@@ -32,6 +34,9 @@ const start = async () => {
     });
     process.on('SIGINT', () => natsClientWrapper.client.close());
     process.on('SIGINT', () => natsClientWrapper.client.close());
+
+    new OrderCreatedListener(natsClientWrapper.client).listen();
+    new OrderCancelledListener(natsClientWrapper.client).listen();
 
     await mongoose.connect(process.env.MONGO_URI, {
       useNewUrlParser: true,

--- a/tickets/src/routes/new.ts
+++ b/tickets/src/routes/new.ts
@@ -33,6 +33,7 @@ router.post('/api/v1/tickets',
       title: ticket.title,
       price: ticket.price,
       userId: ticket.userId,
+      version: ticket.version,
     });
     
     res.status(201).send(ticket);

--- a/tickets/src/routes/update.ts
+++ b/tickets/src/routes/update.ts
@@ -44,7 +44,8 @@ router.put('/api/v1/tickets/:id',
       id: ticket.id,
       title: ticket.title,
       price: ticket.price,
-      userId: ticket.userId
+      userId: ticket.userId,
+      version: ticket.version,
     });
 
     res.send(ticket);

--- a/tickets/src/routes/update.ts
+++ b/tickets/src/routes/update.ts
@@ -1,11 +1,6 @@
 import express, { Request, Response } from 'express';
 import { body } from 'express-validator';
-import {
-  validateRequest,
-  NotFoundError,
-  requireAuth,
-  NotAuthorizedError
-} from '@saheedpass/common';
+import { validateRequest, NotFoundError, requireAuth, NotAuthorizedError, BadRequestError } from '@saheedpass/common';
 import { Ticket } from '../db/models/ticket';
 import { TicketUpdatedPublisher } from '../events/publishers/ticket-update-publisher';
 import { natsClientWrapper } from '../nats-client-wrapper';
@@ -29,6 +24,10 @@ router.put('/api/v1/tickets/:id',
 
     if (!ticket) {
       throw new NotFoundError('Ticket not found');
+    }
+
+    if (ticket.orderId) {
+      throw new BadRequestError('Cannot edit a reserved ticket');
     }
 
     if (ticket.userId !== req.currentUser!.id) {


### PR DESCRIPTION
#### What does this PR do
This PR implements `TicketCreated`, `TicketUpdated`, `OrderCreated` & `OrderCancelled` listeners in Order and Ticket services

#### Description of Task to be completed
- implement `TicketCreated` & `TicketUpdated`  listeners in Orders service
- implement `OrderCreated` & `OrderCancelled` listeners in Tickets service.
- add tests to verify all order listeners work correctly
- add checks to Ticket service update ticket route handler to verify Ticket isn't reserved before editing

#### How should this be manually tested
- In the orders service folder, run `npm run test`
- In the tickets service folder, run `npm run test`

#### What are the relevant pivotal tracker stories?
- NIL

#### Screenshots
- NIL