### PR TITLE
Client / Services Wire Up

### DIFF
--- a/client/components/header.js
+++ b/client/components/header.js
@@ -4,6 +4,8 @@ export default ({ currentUser }) => {
   const links = [
     !currentUser && { label: 'Sign Up', href: '/auth/signup' },
     !currentUser && { label: 'Sign In', href: '/auth/signin' },
+    currentUser && { label: 'Sell Tickets', href: '/tickets/new' },
+    currentUser && { label: 'My Orders', href: '/orders' },
     currentUser && { label: 'Sign Out', href: '/auth/signout' }
   ]
     .filter((linkConfig) => linkConfig)
@@ -17,14 +19,14 @@ export default ({ currentUser }) => {
       );
     });
 
-  return <nav className="navbar navbar-light bg-light">
-    <Link href="/">
-      <a className="navbar-brand">Pass</a>
-    </Link>
-    <div className="d-flex justify-content-end">
-      <ul className="nav d-flex align-items-center">
-        {links}
-      </ul>
-    </div>
-  </nav>
+  return (
+    <nav className="navbar navbar-light bg-light">
+      <Link href="/">
+        <a className="navbar-brand">Pass</a>
+      </Link>
+      <div className="d-flex justify-content-end">
+        <ul className="nav d-flex align-items-center">{links}</ul>
+      </div>
+    </nav>
+  );
 };

--- a/client/hooks/use-request.js
+++ b/client/hooks/use-request.js
@@ -4,10 +4,10 @@ import { useState } from 'react';
 export default ({ url, method, body, onSuccess }) => {
   const [errors, setErrors] = useState(null);
 
-  const doRequest = async () => {
+  const doRequest = async (props = {}) => {
     try {
       setErrors(null);
-      const response = await axios[method](url, body);
+      const response = await axios[method](url, { ...body, ...props });
       onSuccess && onSuccess(response.data);
       return response.data;
     } catch (error) {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5555,6 +5555,11 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
+    "react-stripe-checkout": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/react-stripe-checkout/-/react-stripe-checkout-2.6.3.tgz",
+      "integrity": "sha1-MXOocLBOWjwyGgbSTNU8YDARHEU="
+    },
     "readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
     "bootstrap": "^4.5.0",
     "next": "^9.4.4",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react-dom": "^16.13.1",
+    "react-stripe-checkout": "^2.6.3"
   }
 }

--- a/client/pages/_app.js
+++ b/client/pages/_app.js
@@ -6,7 +6,9 @@ const AppComponent = ({ Component, pageProps, currentUser }) => {
   return (
     <div>
       <Header currentUser={currentUser} />
-      <Component {...pageProps} />
+      <div className="container">
+        <Component currentUser={currentUser} {...pageProps} />
+      </div>
     </div>
   );
 };
@@ -16,7 +18,11 @@ AppComponent.getInitialProps = async (appContext) => {
   const { data } = await client.get('/api/v1/users/currentuser');
   let pageProps = {};
   if (appContext.Component.getInitialProps) {
-    pageProps = await appContext.Component.getInitialProps(appContext.ctx);
+    pageProps = await appContext.Component.getInitialProps(
+      appContext.ctx,
+      client,
+      data.currentUser
+    );
   }
   return { pageProps, ...data };
 };

--- a/client/pages/index.js
+++ b/client/pages/index.js
@@ -1,5 +1,3 @@
-import buildClient from '../api/build-client';
-
 const landingPage = ({ currentUser }) => {
 
   return (
@@ -9,11 +7,8 @@ const landingPage = ({ currentUser }) => {
   );
 };
 
-landingPage.getInitialProps = async (context) => {
-  const client = buildClient(context);
-  const { data } = await client.get('/api/v1/users/currentuser');
-  
-  return data;
+landingPage.getInitialProps = async (context, client, currentUser) => {
+  return {};
 };
 
 export default landingPage;

--- a/client/pages/index.js
+++ b/client/pages/index.js
@@ -1,15 +1,40 @@
-const landingPage = ({ currentUser }) => {
+import Link from 'next/link';
 
+const landingPage = ({ currentUser, tickets }) => {
+  const ticketList = tickets.map((ticket) => {
+    return (
+      <tr key={ticket.id}>
+        <td>{ticket.title}</td>
+        <td>{ticket.price}</td>
+        <td>
+          <Link href="/tickets/[ticketId]" as={`/tickets/${ticket.id}`}>
+            <a>View</a>
+          </Link>
+        </td>
+      </tr>
+    );
+  });
   return (
-    <h1>{ currentUser ?
-      'You are signed in' : 'You are NOT signed in'}
-    </h1>
+    <div>
+      <h1>Tickets</h1>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Price</th>
+            <th>Link</th>
+          </tr>
+        </thead>
+        <tbody>{ticketList}</tbody>
+      </table>
+    </div>
   );
 };
 
 landingPage.getInitialProps = async (context, client, currentUser) => {
-  return {};
+  const { data } = await client.get('/api/v1/tickets');
+
+  return { tickets: data };
 };
 
 export default landingPage;
-

--- a/client/pages/orders/[orderId].js
+++ b/client/pages/orders/[orderId].js
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import Router from 'next/router';
+import StripeCheckout from 'react-stripe-checkout';
+import useRequest from '../../hooks/use-request';
+
+const STRIPE_PUB_KEY =
+  'pk_test_51H0Cq9E0D7FXS4yi0a4YO9dg7pDN3CUvOw6cvwaJfSW4qZ7ybpuCbGRO1liveCpghxHn8Mz7vk5rAFCkjN3moRZI00MN0cIhal';
+
+const OrderShow = ({ order, currentUser }) => {
+  const [timeLeft, setTimeLeft] = useState(0);
+  const { doRequest, errors } = useRequest({
+    url: '/api/v1/payments',
+    method: 'post',
+    body: {
+      orderId: order.id
+    },
+    onSuccess: (payment) => Router.push('/orders')
+  });
+
+  useEffect(() => {
+    const calcTimeLeft = () => {
+      const msLeft = new Date(order.expiresAt) - new Date();
+      setTimeLeft(Math.round(msLeft / (1000 * 60)));
+    };
+    calcTimeLeft();
+    const timerId = setInterval(calcTimeLeft, 1000 * 60);
+
+    return () => {
+      clearInterval(timerId);
+    };
+  }, []);
+
+  if (timeLeft < 0) {
+    return <div>Order Expired</div>;
+  }
+
+  return (
+    <div>
+      {timeLeft} minutes until order expires
+      <StripeCheckout
+        token={({ id }) => doRequest({ token: id })}
+        stripeKey={STRIPE_PUB_KEY}
+        amount={order.ticket.price * 100}
+        email={currentUser.email}
+      />
+      {errors}
+    </div>
+  );
+};
+
+OrderShow.getInitialProps = async (context, client) => {
+  const { orderId } = context.query;
+  const { data } = await client.get(`/api/v1/orders/${orderId}`);
+
+  return { order: data };
+};
+
+export default OrderShow;

--- a/client/pages/orders/index.js
+++ b/client/pages/orders/index.js
@@ -1,0 +1,21 @@
+const OrderIndex = ({ orders }) => {
+  return (
+    <ul>
+      {orders.map((order) => {
+        return (
+          <li key={order.id}>
+            {order.ticket.title} - {order.status}
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+OrderIndex.getInitialProps = async (context, client) => {
+  const { data } = await client.get('/api/v1/orders');
+
+  return { orders: data };
+};
+
+export default OrderIndex;

--- a/client/pages/tickets/[ticketId].js
+++ b/client/pages/tickets/[ticketId].js
@@ -1,0 +1,33 @@
+import Router from 'next/router';
+import useRequest from '../../hooks/use-request';
+
+const TicketShow = ({ ticket }) => {
+  const { doRequest, errors } = useRequest({
+    url: '/api/v1/orders',
+    method: 'post',
+    body: {
+      ticketId: ticket.id
+    },
+    onSuccess: (order) =>
+      Router.push('/orders/[orderId]', `/orders/${order.id}`)
+  });
+  return (
+    <div>
+      <h1>{ticket.title}</h1>
+      <h4>Price: {ticket.price}</h4>
+      {errors}
+      <button onClick={() => doRequest()} className="btn btn-primary">
+        Purchase
+      </button>
+    </div>
+  );
+};
+
+TicketShow.getInitialProps = async (context, client, currentUser) => {
+  const { ticketId } = context.query;
+  const { data } = await client.get(`/api/v1/tickets/${ticketId}`);
+
+  return { ticket: data };
+};
+
+export default TicketShow;

--- a/client/pages/tickets/new.js
+++ b/client/pages/tickets/new.js
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import Router from 'next/router';
+import useRequest from '../../hooks/use-request';
+
+const NewTicket = () => {
+  const [title, setTitle] = useState('');
+  const [price, setPrice] = useState('');
+
+  const { doRequest, errors } = useRequest({
+    url: '/api/v1/tickets',
+    method: 'post',
+    body: {
+      title,
+      price
+    },
+    onSuccess: (ticket) => Router.push('/')
+  });
+  const onSubmit = (event) => {
+    event.preventDefault();
+    doRequest();
+  };
+
+  const onBlur = () => {
+    const value = parseFloat(price);
+
+    if (isNaN(value)) {
+      return;
+    }
+
+    setPrice(value.toFixed(2));
+  };
+
+  return (
+    <div>
+      <h1>Create a Ticket</h1>
+      <form onSubmit={onSubmit}>
+        <div className="form-group">
+          <label>Title</label>
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="form-control"
+          />
+        </div>
+
+        <div className="form-group">
+          <label>Price</label>
+          <input
+            value={price}
+            onBlur={onBlur}
+            onChange={(e) => setPrice(e.target.value)}
+            className="form-control"
+          />
+        </div>
+        {errors}
+        <button className="btn btn-primary">Submit</button>
+      </form>
+    </div>
+  );
+};
+
+export default NewTicket;

--- a/tickets/src/routes/index.ts
+++ b/tickets/src/routes/index.ts
@@ -4,7 +4,9 @@ import { Ticket } from '../db/models/ticket';
 const router = express.Router();
 
 router.get('/api/v1/tickets', async (req: Request, res: Response) => {
-  const tickets = await Ticket.find({});
+  const tickets = await Ticket.find({
+    orderId: undefined
+  });
 
   res.status(200).send(tickets);
 });


### PR DESCRIPTION
#### What does this PR do
This PR makes sure the Client service consumes all services endpoints

#### Description of Task to be completed
- pass `currentUser` object from index page as props to all rendered components
- add page to view and purchase a ticket
- add page to view user orders
- add links to navigate to pages to view and purchase a ticket, and user orders list
- install stripe payment package
- modify `useRequest` hook for passing extra body items during invocation

#### How should this be manually tested
- `npm run test`

#### Screenshots
- NIL